### PR TITLE
Feat/get single book

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 name: Deploy FastAPI
 
 on:
-  push:
+  pull_request:
     branches:
       - main # Change to your deployment branch
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,6 @@ jobs:
           script: |
             cd /home/ubuntu/fastapi-book-project
             git pull origin main
-            source venv/bin/activate
+            source env/bin/activate
             pip install -r requirements.txt
             sudo systemctl restart fastapi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy FastAPI
+
+on:
+  push:
+    branches:
+      - main # Change to your deployment branch
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Deploy to Server
+        uses: appleboy/ssh-action@v0.1.10
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            cd /home/ubuntu/fastapi-book-project
+            git pull origin main
+            source venv/bin/activate
+            pip install -r requirements.txt
+            sudo systemctl restart fastapi

--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -55,6 +55,16 @@ async def update_book(book_id: int, book: Book) -> Book:
         content=db.update_book(book_id, book).model_dump(),
     )
 
+@router.get("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
+async def get_a_book(book_id: int) -> Book:
+    book = db.get_book(book_id)
+
+    if book is None:
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content={"details": "Book not found"},
+        )
+    return book
 
 @router.delete("/{book_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_book(book_id: int) -> None:


### PR DESCRIPTION
This pull request includes significant changes to the deployment workflow and the book retrieval functionality in the FastAPI project. The most important changes include the addition of a new GitHub Actions workflow for deploying the FastAPI application and the implementation of a new endpoint to retrieve a book by its ID.

Deployment workflow:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R1-R27): Added a new GitHub Actions workflow to automate the deployment of the FastAPI application. This workflow triggers on pull requests to the `main` branch and includes steps for checking out the code, deploying it to a server via SSH, installing dependencies, and restarting the FastAPI service.

Book retrieval endpoint:

* [`api/routes/books.py`](diffhunk://#diff-b498d5fa55d94d68c11fae6ee60120c2a5d6134276ddbe267b497926ceaea25eR58-R67): Added a new endpoint `get_a_book` to retrieve a book by its ID. This endpoint returns a 200 OK status with the book details if found, or a 404 Not Found status if the book does not exist.