### PR TITLE
fix: change deployment trigger from pull_request to push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 name: Deploy FastAPI
 
 on:
-  pull_request:
+  push:
     branches:
       - main # Change to your deployment branch
 


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow configuration for deployment. The change modifies the workflow trigger from running on pull requests to running on pushes to the main branch.

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L4-R4): Changed the trigger from `pull_request` to `push` for branches named `main`.