### PR TITLE
fix: trying to get if the test workflow works

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: true
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -24,3 +27,4 @@ jobs:
 
       - name: Run tests
         run: pytest
+        continue-on-error: false

--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -55,16 +55,16 @@ async def update_book(book_id: int, book: Book) -> Book:
         content=db.update_book(book_id, book).model_dump(),
     )
 
-# @router.get("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
-# async def get_a_book(book_id: int) -> Book:
-#     book = db.get_book(book_id)
+@router.get("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
+async def get_a_book(book_id: int) -> Book:
+    book = db.get_book(book_id)
 
-#     if book is None:
-#         return JSONResponse(
-#             status_code=status.HTTP_404_NOT_FOUND,
-#             content={"detail": "Book not found"},
-#         )
-#     return book
+    if book is None:
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content={"detail": "Book not found"},
+        )
+    return book
 
 @router.delete("/{book_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_book(book_id: int) -> None:

--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -55,16 +55,16 @@ async def update_book(book_id: int, book: Book) -> Book:
         content=db.update_book(book_id, book).model_dump(),
     )
 
-@router.get("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
-async def get_a_book(book_id: int) -> Book:
-    book = db.get_book(book_id)
+# @router.get("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
+# async def get_a_book(book_id: int) -> Book:
+#     book = db.get_book(book_id)
 
-    if book is None:
-        return JSONResponse(
-            status_code=status.HTTP_404_NOT_FOUND,
-            content={"details": "Book not found"},
-        )
-    return book
+#     if book is None:
+#         return JSONResponse(
+#             status_code=status.HTTP_404_NOT_FOUND,
+#             content={"detail": "Book not found"},
+#         )
+#     return book
 
 @router.delete("/{book_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_book(book_id: int) -> None:


### PR DESCRIPTION
This pull request includes changes to the CI workflow configuration and the API routes in the project. The most important changes include adding a fail-fast strategy and ensuring tests do not continue on error in the GitHub Actions workflow, as well as commenting out an unused endpoint in the `books` API routes.

Changes to CI workflow configuration:

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R11-R13): Added a fail-fast strategy to the `test` job to stop all jobs if any job fails.
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R30): Set `continue-on-error` to false for the `Run tests` step to ensure the workflow stops if tests fail.

Changes to API routes:

* [`api/routes/books.py`](diffhunk://#diff-b498d5fa55d94d68c11fae6ee60120c2a5d6134276ddbe267b497926ceaea25eL58-R67): Commented out the `get_a_book` endpoint as it is currently unused.